### PR TITLE
docs: add beginner step-by-step setup to both READMEs

### DIFF
--- a/AgentSpec/README.md
+++ b/AgentSpec/README.md
@@ -4,6 +4,71 @@ AgentSpec is a framework for enforcing safety in Large Language Model (LLM) agen
 
 ---
 
+## Beginner Quick Start (Step-by-Step)
+
+Use these steps if this is your first time running the project.
+
+### 1. Open terminal in the `AgentSpec` folder
+
+If you are currently in the repository root:
+
+```bash
+cd AgentSpec
+```
+
+### 2. Create and activate a Python virtual environment
+
+Windows (PowerShell):
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+macOS/Linux:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### 3. Install dependencies
+
+```bash
+pip install -r requirement.txt
+```
+
+### 4. Create `.env` with your API key(s)
+
+Create a `.env` file in this folder and add the keys needed by your selected model provider:
+
+```env
+OPENAI_API_KEY=your_key_here
+ANTHROPIC_API_KEY=your_key_here
+```
+
+### 5. Run basic checks from the menu script
+
+```bash
+bash src/run.sh
+```
+
+Then choose an option in the menu:
+
+- `2` to run parser unit tests
+- `5` to run controlled agent import smoke test
+- `9` to run the full local smoke suite
+
+### 6. Optional: Regenerate parser files
+
+Only needed when grammar changes are made.
+
+```bash
+java -jar ./spec_lang/antlr-4.13.2-complete.jar -Dlanguage=Python3 ./spec_lang/AgentSpec.g4
+```
+
+---
+
 ## 🚀 Getting Started
 
 ### 1. Installation

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 [![Review Assignment Due Date](https://classroom.github.com/assets/deadline-readme-button-22041afd0340ce965d47ae6ef1cefeee28c7c493a6346c4f15d667ab976d596c.svg)](https://classroom.github.com/a/7oQPi1Yr)
+
+# Beginner Guide (Step-by-Step)
+
+This repository contains the AgentSpec project inside the `AgentSpec` folder.
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/UCF-CEN-5016/research-project-claude-make-a-web-app-no-mistakes.git
+cd research-project-claude-make-a-web-app-no-mistakes
+```
+
+## 2. Move into the project folder
+
+```bash
+cd AgentSpec
+```
+
+## 3. Create a Python virtual environment
+
+Windows (PowerShell):
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+macOS/Linux:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+## 4. Install dependencies
+
+```bash
+pip install -r requirement.txt
+```
+
+## 5. Configure environment variables
+
+Create a `.env` file in the `AgentSpec` folder. Add your keys as needed, for example:
+
+```env
+OPENAI_API_KEY=your_key_here
+ANTHROPIC_API_KEY=your_key_here
+```
+
+## 6. Run the test menu
+
+From the `AgentSpec` folder:
+
+```bash
+bash src/run.sh
+```
+
+If you are on Windows and do not have bash, use Git Bash, WSL, or run the individual Python commands shown in the project README.
+
+## 7. Read the full project documentation
+
+See `AgentSpec/README.md` for full usage details, rule customization, and evaluation notes.


### PR DESCRIPTION
Description 
This PR adds a beginner-friendly setup flow to both README files so first-time contributors can get the project running with minimal confusion.

What changed
- Added clear, ordered setup steps in the root README for navigating into the project and starting from scratch.
- Added a Beginner Quick Start section in the AgentSpec README with simple install and run instructions.
- Included practical guidance for:
  - creating and activating a virtual environment
  - installing dependencies
  - creating a .env file for API keys
  - running the menu-based test script
  - optional parser regeneration

Why
- Reduces onboarding friction for students and new contributors.
- Makes setup more consistent across environments.
- Helps users validate their environment quickly before deeper development work.

Scope
- Documentation-only changes.
- No code logic or runtime behavior changes.