### PR TITLE
Adding CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -53,12 +53,12 @@ jobs:
           mkdir -p /tmp/agentspec-logs
           docker compose run --rm -e OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" agentspec 1 2>&1 | tee /tmp/agentspec-logs/test1.log
 
-      - name: Run full smoke suite (9)
+      - name: Run parser unit tests (2)
         env:
           CI: true
         run: |
           set -o pipefail
-          docker compose run --rm -e OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" agentspec 9 2>&1 | tee /tmp/agentspec-logs/test9.log
+          docker compose run --rm -e OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" agentspec 2 2>&1 | tee /tmp/agentspec-logs/test2.log
 
       - name: Upload agentspec logs
         if: always()

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,68 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+      - development
+
+jobs:
+  docker-build:
+    name: docker-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build compose images
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker compose version
+          docker compose build --parallel --pull
+
+      - name: Build AgentSpec Dockerfile (fallback)
+        run: |
+          if [ -f AgentSpec/Dockerfile ]; then 
+            docker build -f AgentSpec/Dockerfile -t agentspec-ci:${{ github.sha }} AgentSpec; 
+          else 
+            echo "No AgentSpec/Dockerfile found, skipping direct build"; 
+          fi
+
+  smoke:
+    name: smoke
+    needs: docker-build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run menu test 1 (LangChain smoke demo)
+        env:
+          CI: true
+        run: |
+          set -o pipefail
+          mkdir -p /tmp/agentspec-logs
+          docker compose run --rm -e OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" agentspec 1 2>&1 | tee /tmp/agentspec-logs/test1.log
+
+      - name: Run full smoke suite (9)
+        env:
+          CI: true
+        run: |
+          set -o pipefail
+          docker compose run --rm -e OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" agentspec 9 2>&1 | tee /tmp/agentspec-logs/test9.log
+
+      - name: Upload agentspec logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentspec-logs
+          path: /tmp/agentspec-logs

--- a/AgentSpec/.dockerignore
+++ b/AgentSpec/.dockerignore
@@ -1,0 +1,63 @@
+# Python build artifacts
+__pycache__
+*.py[cod]
+*.so
+*.egg
+*.egg-info
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+
+# Virtual environments
+.venv
+.env
+
+# IDE and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Documentation
+*.md
+docs/
+
+# Build context exclusions
+.dockerignore
+Dockerfile
+docker-compose.yml
+
+# Test and benchmark data (large files)
+expres/
+benchmarks/
+*.jsonl
+
+# Development and CI
+.github/
+.gitlab-ci.yml
+.travis.yml
+Makefile
+tox.ini
+
+# OS-specific
+.vscode
+.DS_Store
+Thumbs.db

--- a/AgentSpec/.env_example
+++ b/AgentSpec/.env_example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY="Your Key here"

--- a/AgentSpec/Dockerfile
+++ b/AgentSpec/Dockerfile
@@ -1,0 +1,48 @@
+# Multi-stage Dockerfile for AgentSpec
+# Builds a container with Python 3.12 and Java 17 for full testing capabilities
+
+# Stage 1: Builder
+FROM python:3.12-slim as builder
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Stage 2: Runtime
+FROM python:3.12-slim
+
+# Install runtime dependencies including Java for ANTLR
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-21-jre-headless \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app:$PYTHONPATH
+
+# Set working directory
+WORKDIR /app
+
+# Copy entire project (build context is AgentSpec/)
+COPY . /app
+
+# Install Python dependencies
+# Use requirement.txt if available, otherwise use pyproject.toml
+RUN if [ -f "requirement.txt" ]; then \
+        pip install --no-cache-dir -r requirement.txt; \
+    else \
+        pip install --no-cache-dir -e .; \
+    fi
+
+# Make the run script executable
+RUN chmod +x src/run.sh
+
+# Set entrypoint to the bash script
+ENTRYPOINT ["bash", "src/run.sh"]
+
+# Default command (can be overridden)
+CMD []

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,97 @@
+# Running AgentSpec with Docker
+
+## First-Time Setup
+Change the .env_example file to just env and add your real API key
+Run these commands from the project root:
+
+```bash
+docker compose build
+docker compose run --rm agentspec
+```
+
+## Quick Start
+
+**Interactive menu (works reliably on local machines and Codespaces):**
+```bash
+docker compose run --rm agentspec
+```
+
+Type a number and press Enter.
+
+**Optional (may work depending on terminal/input forwarding):**
+```bash
+docker compose up
+```
+
+**Run specific test:**
+```bash
+docker compose run --rm agentspec 9    # Full smoke suite (tests 2,5,6,7)
+docker compose run --rm agentspec 2    # Parser unit tests
+docker compose run --rm agentspec 5    # Controlled agent import test
+docker compose run --rm agentspec 6    # Predicate registry test
+docker compose run --rm agentspec 7    # Bytecode compilation test
+docker compose run --rm agentspec 8    # Regenerate ANTLR parser (requires Java)
+```
+
+## Setup Environment
+
+Before running Docker for the first time, you must rename `.env_example` to `.env` and add a real API key:
+```bash
+cp AgentSpec/.env_example AgentSpec/.env
+# Edit AgentSpec/.env and add OPENAI_API_KEY="sk-..."
+```
+
+## Build Image
+
+```bash
+docker compose build              # Build image
+docker compose build --no-cache   # Rebuild from scratch
+```
+
+## Common Commands
+
+```bash
+docker compose run --rm agentspec            # Interactive menu (recommended)
+docker compose up                            # Alternative (terminal-dependent)
+docker compose run --rm agentspec 9          # Run full test suite
+docker compose run --rm agentspec bash       # Enter container shell
+docker images | grep agentspec               # Check image size (~1.2GB)
+```
+
+## Troubleshooting
+
+**"No such file or directory: .env"**
+```bash
+cp AgentSpec/.env_example AgentSpec/.env
+```
+
+**"OpenAI API key not found"**
+```bash
+cat AgentSpec/.env
+docker compose run --rm agentspec bash -c "echo \$OPENAI_API_KEY"
+```
+
+**"Permission denied: src/run.sh"**
+```bash
+docker compose build --no-cache
+```
+
+**Clean up Docker:**
+```bash
+docker system prune -a
+```
+
+## Test Menu Reference
+
+| #  | Test |
+|----|------|
+| 1  | LangChain smoke demo |
+| 2  | Parser unit tests |
+| 3  | Parse inline rule: user inspection |
+| 4  | Parse inline rule: stop |
+| 5  | Controlled agent import test |
+| 6  | Predicate registry test |
+| 7  | Bytecode compilation test |
+| 8  | Regenerate parser (requires Java) |
+| 9  | Full local smoke suite |
+| 0  | Exit |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  agentspec:
+    build:
+      context: ./AgentSpec
+      dockerfile: Dockerfile
+    
+    # Interactive terminal support for numpad menu
+    stdin_open: true
+    tty: true
+    
+    # Environment variables
+    environment:
+      PYTHONUNBUFFERED: "1"
+      PYTHONDONTWRITEBYTECODE: "1"
+    
+    # Mount local .env file for API credentials
+    volumes:
+      - ./AgentSpec/.env:/app/.env:ro
+    
+    # Working directory
+    working_dir: /app
+    
+    # Keep container running for interactive use
+    restart: "no"
+    
+    # Pass arguments to entrypoint if needed
+    # Override with: docker compose run agentspec 9
+    # Or just docker compose up for interactive menu


### PR DESCRIPTION
- **What?**: Added Docker-based PR checks workflow so PRs build the images and run menu tests before merging.
- **Why?:** Ensure PRs validate in the same Docker environment contributors use locally (no runner-level installs), catch image/test failures early, and reduce “works on my machine” issues.
- **How?:** First builds docker image then tests option 1 and 2 of the keypad
- **Testing?:** Manual test locally
- **Anything else?:** OPENAI_API_KEY was added to the repo secrets to ensure that these tests could run

**MAKE SURE TO MERGE THIS ONLY AFTER MERGING #43** 

User Stories:
resolves #35 
Issues: 
resolves #39 
resolves #40 
resolves #41 